### PR TITLE
Add video processing utilities

### DIFF
--- a/BE/config/constants.py
+++ b/BE/config/constants.py
@@ -12,6 +12,10 @@ API_TIMEOUT_SEC = 180
 MAX_CHUNK_SIZE = 100000  # Kích thước tối đa của một chunk văn bản
 SUPPORTED_DOC_FORMATS = ['.pdf', '.docx', '.txt', '.md']
 
+# Video processing
+SUPPORTED_VIDEO_FORMATS = ['.mp4', '.mov', '.avi', '.mkv', '.webm']
+MAX_VIDEO_SIZE_MB = 500
+
 # Kích thước ảnh xem trước
 PREVIEW_MAX_SIZE = 150
 

--- a/BE/core/video_processing.py
+++ b/BE/core/video_processing.py
@@ -1,0 +1,235 @@
+import os
+import json
+import subprocess
+import logging
+from typing import Dict, Any, List, Optional
+
+from openai import OpenAI
+from BE.utils.helpers import ensure_dir_exists
+
+logger = logging.getLogger('ImageSearchApp')
+
+def _run_ffprobe(video_path: str) -> Dict[str, Any]:
+    """Run ffprobe and return parsed JSON metadata."""
+    try:
+        cmd = [
+            'ffprobe', '-v', 'error', '-print_format', 'json',
+            '-show_format', '-show_streams', video_path
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return json.loads(result.stdout)
+    except FileNotFoundError:
+        logger.error("ffprobe not found. Please install ffmpeg.")
+        return {}
+    except Exception as e:
+        logger.error(f"ffprobe failed for {video_path}: {e}")
+        return {}
+
+
+def extract_comprehensive_metadata(video_path: str) -> Dict[str, Any]:
+    """Extract basic and technical metadata, including GPS if available."""
+    metadata = {
+        'success': False,
+        'basic': {},
+        'technical': {},
+        'gps': {},
+        'exif': {},
+    }
+    if not os.path.isfile(video_path):
+        metadata['error'] = 'File does not exist'
+        return metadata
+    data = _run_ffprobe(video_path)
+    if not data:
+        metadata['error'] = 'Could not parse metadata'
+        return metadata
+    try:
+        format_info = data.get('format', {})
+        streams = data.get('streams', [])
+        video_stream = next((s for s in streams if s.get('codec_type') == 'video'), {})
+        audio_stream = next((s for s in streams if s.get('codec_type') == 'audio'), {})
+
+        metadata['basic'] = {
+            'filename': os.path.basename(video_path),
+            'duration': float(format_info.get('duration', 0)),
+            'size': int(format_info.get('size', 0)),
+            'bit_rate': int(format_info.get('bit_rate', 0)),
+            'format': format_info.get('format_long_name'),
+            'resolution': f"{video_stream.get('width')}x{video_stream.get('height')}" if video_stream else '',
+        }
+        metadata['technical'] = {
+            'video_codec': video_stream.get('codec_name'),
+            'audio_codec': audio_stream.get('codec_name'),
+            'frame_rate': eval(video_stream.get('r_frame_rate', '0')) if video_stream else 0,
+            'color_space': video_stream.get('color_space'),
+        }
+        # GPS and EXIF-like data
+        tags = format_info.get('tags', {})
+        if tags:
+            gps_keys = [k for k in tags.keys() if 'location' in k.lower() or 'gps' in k.lower()]
+            metadata['gps'] = {k: tags[k] for k in gps_keys}
+            metadata['exif'] = tags
+        metadata['success'] = True
+    except Exception as e:  # pragma: no cover - defensive parsing
+        logger.error(f"Metadata extraction failed for {video_path}: {e}")
+        metadata['error'] = str(e)
+    return metadata
+
+
+def transcribe_with_timestamps(video_path: str, language: str = 'en', api_key: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Transcribe audio with word-level timestamps using Whisper."""
+    if not os.path.isfile(video_path):
+        raise FileNotFoundError(video_path)
+    api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("CHATGPT_API_KEY")
+    if not api_key:
+        raise ValueError("OpenAI API key not configured")
+    try:
+        client = OpenAI(api_key=api_key)
+        with open(video_path, 'rb') as f:
+            resp = client.audio.transcriptions.create(
+                model='whisper-1',
+                file=f,
+                response_format='verbose_json',
+                timestamp_granularities=['word'],
+                language=language
+            )
+        return resp.get('segments', [])
+    except Exception as e:
+        logger.error(f"Transcription failed for {video_path}: {e}")
+        raise
+
+
+def export_transcript_multiple_formats(transcript: List[Dict[str, Any]], output_dir: str,
+                                       base_filename: str) -> Dict[str, str]:
+    """Export transcript to multiple formats."""
+    ensure_dir_exists(output_dir)
+    file_paths: Dict[str, str] = {}
+    text_lines = []
+    for seg in transcript:
+        start = seg.get('start', 0)
+        end = seg.get('end', 0)
+        text = seg.get('text', '')
+        speaker = seg.get('speaker', '')
+        line = f"[{start:.2f}-{end:.2f}] {speaker} {text}".strip()
+        text_lines.append(line)
+    txt_path = os.path.join(output_dir, base_filename + '.txt')
+    with open(txt_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(text_lines))
+    file_paths['txt'] = txt_path
+
+    # JSON
+    json_path = os.path.join(output_dir, base_filename + '.json')
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(transcript, f, indent=2, ensure_ascii=False)
+    file_paths['json'] = json_path
+
+    # CSV
+    import csv
+    csv_path = os.path.join(output_dir, base_filename + '.csv')
+    with open(csv_path, 'w', newline='', encoding='utf-8') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(['start', 'end', 'speaker', 'text'])
+        for seg in transcript:
+            writer.writerow([
+                seg.get('start', 0),
+                seg.get('end', 0),
+                seg.get('speaker', ''),
+                seg.get('text', '')
+            ])
+    file_paths['csv'] = csv_path
+
+    # SRT
+    srt_path = os.path.join(output_dir, base_filename + '.srt')
+    with open(srt_path, 'w', encoding='utf-8') as f:
+        for i, seg in enumerate(transcript, 1):
+            start = seg.get('start', 0)
+            end = seg.get('end', 0)
+            f.write(str(i) + '\n')
+            f.write(_format_srt_time(start) + ' --> ' + _format_srt_time(end) + '\n')
+            f.write(seg.get('text', '') + '\n\n')
+    file_paths['srt'] = srt_path
+
+    # DOCX
+    try:
+        from docx import Document
+        doc = Document()
+        for seg in transcript:
+            ts = f"[{_format_srt_time(seg.get('start',0))}]"
+            doc.add_paragraph(f"{ts} {seg.get('text','')}")
+        docx_path = os.path.join(output_dir, base_filename + '.docx')
+        doc.save(docx_path)
+        file_paths['docx'] = docx_path
+    except Exception as e:
+        logger.warning(f"DOCX export failed: {e}")
+    return file_paths
+
+
+def _format_srt_time(seconds: float) -> str:
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    ms = int((seconds - int(seconds)) * 1000)
+    return f"{h:02}:{m:02}:{s:02},{ms:03}"
+
+
+def extract_audio_to_mp3(video_path: str, output_path: str) -> str:
+    """Extract audio track to an MP3 file using ffmpeg."""
+    try:
+        cmd = [
+            'ffmpeg', '-y', '-i', video_path, '-vn', '-acodec', 'libmp3lame', output_path
+        ]
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return output_path
+    except Exception as e:
+        logger.error(f"Audio extraction failed for {video_path}: {e}")
+        raise
+
+
+def extract_thumbnails(video_path: str, output_dir: str, interval: int = 10) -> List[str]:
+    """Extract thumbnails every `interval` seconds using ffmpeg."""
+    ensure_dir_exists(output_dir)
+    try:
+        cmd = [
+            'ffmpeg', '-i', video_path, '-vf', f"fps=1/{interval}",
+            os.path.join(output_dir, 'thumb_%04d.jpg')
+        ]
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        files = sorted([os.path.join(output_dir, f) for f in os.listdir(output_dir) if f.startswith('thumb_')])
+        return files
+    except Exception as e:
+        logger.error(f"Thumbnail extraction failed for {video_path}: {e}")
+        return []
+
+
+def generate_video_analysis_report(metadata: Dict[str, Any], transcript_files: Dict[str, str],
+                                   thumbnails: List[str], output_path: str) -> str:
+    """Generate a simple analysis report summarizing metadata and transcript."""
+    try:
+        from docx import Document
+        doc = Document()
+        doc.add_heading('Video Analysis Report', 0)
+        doc.add_heading('Metadata', level=1)
+        for k, v in metadata.get('basic', {}).items():
+            doc.add_paragraph(f"{k}: {v}")
+        doc.add_heading('Transcript', level=1)
+        txt = transcript_files.get('txt')
+        if txt and os.path.isfile(txt):
+            with open(txt, 'r', encoding='utf-8') as f:
+                for line in f:
+                    doc.add_paragraph(line.strip())
+        doc.add_heading('Thumbnails', level=1)
+        for thumb in thumbnails:
+            doc.add_picture(thumb, width=None)
+        doc.save(output_path)
+        return output_path
+    except Exception as e:
+        logger.error(f"Report generation failed: {e}")
+        raise
+
+__all__ = [
+    'extract_comprehensive_metadata',
+    'transcribe_with_timestamps',
+    'extract_audio_to_mp3',
+    'export_transcript_multiple_formats',
+    'extract_thumbnails',
+    'generate_video_analysis_report',
+]

--- a/FE/index.html
+++ b/FE/index.html
@@ -82,6 +82,13 @@
                     <span class="hidden sm:inline">Document Summary</span>
                     <span class="sm:hidden">Docs</span>
                 </button>
+                <button @click="activeTab = 'video-processing'"
+                    :class="activeTab === 'video-processing' ? 'tab-button active' : 'tab-button'"
+                    class="px-3 sm:px-6 py-2 font-medium rounded-t-lg transition-colors text-sm sm:text-base">
+                    <i class="fas fa-video mr-1 sm:mr-2"></i>
+                    <span class="hidden sm:inline">Video Processing</span>
+                    <span class="sm:hidden">Video</span>
+                </button>
             </nav>
 
             <div class="flex items-center space-x-2 sm:space-x-4">
@@ -918,6 +925,57 @@
                 </div>
             </div>
         </div>
+
+        <div x-show="activeTab === 'video-processing'" x-transition:enter="transition ease-out duration-300"
+            x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" class="h-full">
+            <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 p-4 sm:p-6 max-w-screen-2xl mx-auto">
+                <div class="lg:col-span-3 space-y-4">
+                    <div class="card bg-white rounded-lg shadow">
+                        <div class="p-4">
+                            <h3 class="font-medium text-gray-900 mb-3 flex items-center"><i
+                                    class="fas fa-upload mr-2 text-blue-500"></i> Upload Video</h3>
+                            <div class="upload-area p-5 text-center text-sm" @click="browseVideoFiles()"
+                                @dragover.prevent="$el.classList.add('drag-active')"
+                                @dragleave.prevent="$el.classList.remove('drag-active')"
+                                @drop.prevent="handleVideoDrop($event); $el.classList.remove('drag-active')">
+                                <i class="fas fa-video text-2xl text-gray-400 mb-2"></i>
+                                <p class="text-gray-500 mb-2">Drag video or click to browse</p>
+                                <p class="text-xs text-gray-400">MP4, MOV, AVI, MKV, WEBM</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card bg-white rounded-lg shadow">
+                        <div class="p-4 space-y-2">
+                            <h3 class="font-medium text-gray-900 mb-2 flex items-center"><i
+                                    class="fas fa-cogs mr-2 text-blue-500"></i> Processing Actions</h3>
+                            <div class="space-y-1 text-sm">
+                                <label class="flex items-center space-x-2"><input type="checkbox" x-model="videoActions.metadata"> Extract Metadata</label>
+                                <label class="flex items-center space-x-2"><input type="checkbox" x-model="videoActions.audio"> Extract Audio → MP3</label>
+                                <label class="flex items-center space-x-2"><input type="checkbox" x-model="videoActions.transcribe"> Transcribe Audio → Text</label>
+                                <label class="flex items-center space-x-2"><input type="checkbox" x-model="videoActions.export"> Export Transcript</label>
+                                <label class="flex items-center space-x-2"><input type="checkbox" x-model="videoActions.report"> Generate Summary Report</label>
+                            </div>
+                            <button class="btn btn-primary w-full mt-2" @click="runVideoActions()">Run Selected</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="lg:col-span-9 space-y-4">
+                    <template x-if="selectedVideo">
+                        <div class="card p-4">
+                            <video controls class="w-full" :src="selectedVideo.preview"></video>
+                        </div>
+                    </template>
+                    <div class="card p-4" x-show="videoMetadata">
+                        <pre class="text-xs whitespace-pre-wrap" x-text="JSON.stringify(videoMetadata, null, 2)"></pre>
+                    </div>
+                    <div class="card p-4" x-show="videoTranscript">
+                        <pre class="text-xs whitespace-pre-wrap" x-text="videoTranscript"></pre>
+                    </div>
+                </div>
+            </div>
+        </div>
     </main>
 
     <footer
@@ -1029,6 +1087,7 @@
     <script src="js/components/image-vision.js"></script>
     <script src="js/components/image-detection.js"></script>
     <script src="js/components/image-metadata.js"></script>
+    <script src="js/components/video-analysis.js"></script>
     <script src="js/utils/notifications.js"></script>
     <script src="js/utils/chart-renderer.js"></script>
     <script src="js/app.js"></script>

--- a/FE/js/components/common.js
+++ b/FE/js/components/common.js
@@ -109,6 +109,19 @@ const Common = {
         URL.revokeObjectURL(url);
     },
 
+    downloadBase64File(dataUrl, filename) {
+        try {
+            const [header, b64] = dataUrl.split(',');
+            const mime = (header.match(/data:(.*);base64/) || [])[1] || 'application/octet-stream';
+            const binary = atob(b64);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+            this.downloadAsFile(bytes, filename, mime);
+        } catch (e) {
+            console.error('downloadBase64File failed', e);
+        }
+    },
+
     // Animate element with CSS classes
     animateElement(element, animationClass, duration = 300) {
         return new Promise(resolve => {

--- a/FE/js/components/video-analysis.js
+++ b/FE/js/components/video-analysis.js
@@ -1,0 +1,73 @@
+// Enhanced Toolkit v2.0 - Video Processing Component
+// Provides utilities for uploading videos, metadata extraction, and transcription
+
+const VideoAnalysis = {
+    validateVideoFile(file) {
+        const validExtensions = ['.mp4', '.mov', '.avi', '.mkv', '.webm'];
+        const maxSize = 500 * 1024 * 1024; // 500MB
+        const ext = '.' + file.name.split('.').pop().toLowerCase();
+        if (!validExtensions.includes(ext)) {
+            return { valid: false, error: 'Unsupported video format' };
+        }
+        if (file.size > maxSize) {
+            return { valid: false, error: 'Video file too large (500MB limit)' };
+        }
+        return { valid: true };
+    },
+
+    async generatePreview(file) {
+        return FileHandler.createFilePreview(file, 'video');
+    },
+
+    async extractMetadata(base64Data, filename) {
+        try {
+            const result = await eel.extract_video_metadata(base64Data, filename)();
+            return result;
+        } catch (e) {
+            console.error('Metadata extraction failed', e);
+            return { success: false, error: e.message || 'Metadata error' };
+        }
+    },
+
+    async transcribeVideo(base64Data, filename) {
+        try {
+            const result = await eel.transcribe_video_async_web(base64Data, filename)();
+            return result;
+        } catch (e) {
+            console.error('Transcription failed', e);
+            return { success: false, error: e.message || 'Transcription error' };
+        }
+    },
+
+    async extractAudio(base64Data, filename) {
+        try {
+            const result = await eel.extract_video_audio(base64Data, filename)();
+            return result;
+        } catch (e) {
+            console.error('Audio extraction failed', e);
+            return { success: false, error: e.message || 'Audio error' };
+        }
+    },
+
+    async exportTranscript(segments, baseName) {
+        try {
+            const result = await eel.export_video_transcript(segments, baseName)();
+            return result;
+        } catch (e) {
+            console.error('Transcript export failed', e);
+            return { success: false, error: e.message || 'Export error' };
+        }
+    },
+
+    async generateReport(base64Data, filename) {
+        try {
+            const result = await eel.generate_video_report(base64Data, filename)();
+            return result;
+        } catch (e) {
+            console.error('Report generation failed', e);
+            return { success: false, error: e.message || 'Report error' };
+        }
+    }
+};
+
+window.VideoAnalysis = VideoAnalysis;

--- a/FE/js/utils/file-handler.js
+++ b/FE/js/utils/file-handler.js
@@ -15,6 +15,12 @@ const FileHandler = {
             mimeTypes: ['application/pdf', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'text/plain', 'text/markdown'],
             maxSize: 50 * 1024 * 1024, // 50MB
             description: 'Document files'
+        },
+        video: {
+            extensions: ['.mp4', '.mov', '.avi', '.mkv', '.webm'],
+            mimeTypes: ['video/mp4', 'video/quicktime', 'video/x-msvideo', 'video/x-matroska', 'video/webm'],
+            maxSize: 500 * 1024 * 1024,
+            description: 'Video files'
         }
     },
 
@@ -226,6 +232,8 @@ const FileHandler = {
             switch (previewType === 'auto' ? fileType : previewType) {
                 case 'image':
                     return await this.createImagePreview(file);
+                case 'video':
+                    return await this.createVideoPreview(file);
                 case 'text':
                     return await this.createTextPreview(file);
                 case 'document':
@@ -246,6 +254,15 @@ const FileHandler = {
             type: 'image',
             content: dataUrl,
             metadata: await this.getImageMetadata(file)
+        };
+    },
+
+    // Create video preview
+    async createVideoPreview(file) {
+        const url = URL.createObjectURL(file);
+        return {
+            type: 'video',
+            content: url
         };
     },
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Enhanced Toolkit is a Python and JavaScript application for reverse image search
 - AI-powered image description using the OpenAI Vision API
 - Document summarization across multiple models (DeepSeek, Grok, ChatGPT)
 - Image metadata extraction and analysis
+- Video processing with transcription and metadata export
 - Web interface built with Tailwind CSS, Alpine.js, and Chart.js
 
 ## Technical Requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 PyPDF2
 docx2txt
+python-docx
+openpyxl
 Pillow
 matplotlib
 numpy


### PR DESCRIPTION
## Summary
- refine video_processing utilities: add ffprobe check, API-key aware transcription, and audio extraction
- expose new backend endpoints for audio extraction, transcript export, and report generation
- extend frontend VideoAnalysis component and app logic to handle audio and transcript exports
- add helper to download base64 files on frontend
- fix missing Optional import in video processing module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685620910eb88325b6fce008afaaa3ce