### PR TITLE
Add automatic FFmpeg download

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ eel
 cloudinary
 piexif>=1.1.3
 imagehash>=4.3.1
+imageio-ffmpeg


### PR DESCRIPTION
## Summary
- add `imageio-ffmpeg` dependency
- automatically download FFmpeg executables when needed
- ensure ffprobe/ffmpeg availability in video metadata extraction and transcription

## Testing
- `pytest -q`
- `python -m py_compile BE/core/video_processing.py`

------
https://chatgpt.com/codex/tasks/task_b_685b8400b5c08325a581251fc25490c3